### PR TITLE
Feature/auto launch game

### DIFF
--- a/project/SPT.Launcher.Base/Helpers/LauncherSettingsProvider.cs
+++ b/project/SPT.Launcher.Base/Helpers/LauncherSettingsProvider.cs
@@ -111,6 +111,20 @@ namespace SPT.Launcher.Helpers
             set => SetProperty(ref _useAutoLogin, value);
         }
 
+        private bool _autoLaunchGame;
+        public bool AutoLaunchGame
+        {
+            get => _autoLaunchGame;
+            set => SetProperty(ref _autoLaunchGame, value);
+        }
+
+        private int _autoLaunchDelay = 5;
+        public int AutoLaunchDelay
+        {
+            get => _autoLaunchDelay;
+            set => SetProperty(ref _autoLaunchDelay, value);
+        }
+
         private bool _isDevMode;
 
         public bool IsDevMode
@@ -144,6 +158,8 @@ namespace SPT.Launcher.Helpers
                 LogManager.Instance.Info($"Creating launcher config: {LauncherSettingsProvider.DefaultSettingsFileLocation}");
                 LauncherStartGameAction = LauncherAction.MinimizeAction;
                 UseAutoLogin = true;
+                AutoLaunchGame = false;
+                AutoLaunchDelay = 5;
                 GamePath = Environment.CurrentDirectory;
                 IsDevMode = false;
 

--- a/project/SPT.Launcher.Base/Helpers/LocalizationProvider.cs
+++ b/project/SPT.Launcher.Base/Helpers/LocalizationProvider.cs
@@ -192,6 +192,8 @@ namespace SPT.Launcher.Helpers
             englishLocale.open_link_question_format_1 = "Are you sure you want to open the following link: \n{0}";
             englishLocale.open_link = "Open Link";
             englishLocale.dev_mode = "Developer Mode";
+            englishLocale.auto_launch_game = "Auto-launch game after authentication";
+            englishLocale.auto_launch_delay = "Delay (sec)";
             englishLocale.failed_to_save_settings = "Failed to save settings";
             englishLocale.register_failed_name_limit = "name cannot exceed 15 characters";
             englishLocale.copy_failed = "Failed to copy data to clipboard";
@@ -279,6 +281,24 @@ namespace SPT.Launcher.Helpers
         {
             get => _dev_mode;
             set => SetProperty(ref _dev_mode, value);
+        }
+        #endregion
+
+        #region auto_launch_game
+        private string _auto_launch_game;
+        public string auto_launch_game
+        {
+            get => _auto_launch_game;
+            set => SetProperty(ref _auto_launch_game, value);
+        }
+        #endregion
+
+        #region auto_launch_delay
+        private string _auto_launch_delay;
+        public string auto_launch_delay
+        {
+            get => _auto_launch_delay;
+            set => SetProperty(ref _auto_launch_delay, value);
         }
         #endregion
 

--- a/project/SPT.Launcher/SPT_Data/Launcher/Locales/English.json
+++ b/project/SPT.Launcher/SPT_Data/Launcher/Locales/English.json
@@ -95,6 +95,8 @@
   "open_link_question_format_1": "Are you sure you want to open the following link: \n{0}",
   "open_link": "Open Link",
   "dev_mode": "Developer Mode",
+  "auto_launch_game": "Auto-launch game after authentication",
+  "auto_launch_delay": "Delay (sec)",
   "failed_to_save_settings": "Failed to save settings",
   "core_dll_file_version_mismatch": "Your BepinEx/plugins/spt/spt-core.dll file version doesn't match what was expected and is unable to start. Try reinstalling SPT",
   "register_failed_name_limit": "name cannot exceed 15 characters",

--- a/project/SPT.Launcher/SPT_Data/Launcher/Locales/Russian.json
+++ b/project/SPT.Launcher/SPT_Data/Launcher/Locales/Russian.json
@@ -95,6 +95,8 @@
   "open_link_question_format_1": "Вы уверены, что хотите открыть следующую ссылку? \n{0}",
   "open_link": "Открыть ссылку",
   "dev_mode": "Режим разработчика",
+  "auto_launch_game": "Автоматически запускать игру после авторизации",
+  "auto_launch_delay": "Задержка (сек)",
   "failed_to_save_settings": "Не удалось сохранить настройки",
   "core_dll_file_version_mismatch": "Версия файла BepinEx/plugins/spt/spt-core.dll не совпадает с ожидаемой версией, из-за чего запуск невозможен. Попытайтесь переустановить SPT",
   "register_failed_name_limit": "длина имени не может превышать 15 символов",

--- a/project/SPT.Launcher/ViewModels/LoginViewModel.cs
+++ b/project/SPT.Launcher/ViewModels/LoginViewModel.cs
@@ -41,7 +41,7 @@ namespace SPT.Launcher.ViewModels
                             }
 
                             LauncherSettingsProvider.Instance.SaveSettings();
-                            NavigateTo(new ProfileViewModel(HostScreen));
+                            NavigateTo(new ProfileViewModel(HostScreen, LauncherSettingsProvider.Instance.AutoLaunchGame));
                             break;
                         }
                     case AccountStatus.LoginFailed:
@@ -72,7 +72,7 @@ namespace SPT.Launcher.ViewModels
 
                                                 LauncherSettingsProvider.Instance.SaveSettings();
                                                 SendNotification(LocalizationProvider.Instance.profile_created, Login.Username, NotificationType.Success);
-                                                NavigateTo(new ProfileViewModel(HostScreen));
+                                                NavigateTo(new ProfileViewModel(HostScreen, LauncherSettingsProvider.Instance.AutoLaunchGame));
                                                 break;
                                             }
                                         case AccountStatus.RegisterFailed:

--- a/project/SPT.Launcher/ViewModels/ProfileViewModel.cs
+++ b/project/SPT.Launcher/ViewModels/ProfileViewModel.cs
@@ -51,7 +51,7 @@ namespace SPT.Launcher.ViewModels
 
         private readonly ProcessMonitor _monitor;
 
-        public ProfileViewModel(IScreen Host) : base(Host)
+        public ProfileViewModel(IScreen Host, bool AutoLaunch = false) : base(Host)
         {
             // cache and load side image if profile has a side
             if(AccountManager.SelectedProfileInfo != null && AccountManager.SelectedProfileInfo.Side != null)
@@ -66,6 +66,19 @@ namespace SPT.Launcher.ViewModels
             CurrentEdition = AccountManager.SelectedAccount.edition;
 
             CurrentId = AccountManager.SelectedAccount.id;
+
+            // Автозапуск игры
+            if (AutoLaunch && LauncherSettingsProvider.Instance.AutoLaunchGame)
+            {
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(LauncherSettingsProvider.Instance.AutoLaunchDelay * 1000);
+                    await Dispatcher.UIThread.InvokeAsync(async () =>
+                    {
+                        await StartGameCommand();
+                    });
+                });
+            }
         }
 
         private async Task GameVersionCheck()

--- a/project/SPT.Launcher/ViewModels/SettingsViewModel.cs
+++ b/project/SPT.Launcher/ViewModels/SettingsViewModel.cs
@@ -242,5 +242,26 @@ namespace SPT.Launcher.ViewModels
                 LauncherSettingsProvider.Instance.GamePath = dir[0].Path.LocalPath;
             }
         }
+
+        // Свойства для автозапуска игры
+        public bool AutoLaunchGame
+        {
+            get => LauncherSettingsProvider.Instance.AutoLaunchGame;
+            set
+            {
+                LauncherSettingsProvider.Instance.AutoLaunchGame = value;
+                this.RaisePropertyChanged();
+            }
+        }
+
+        public int AutoLaunchDelay
+        {
+            get => LauncherSettingsProvider.Instance.AutoLaunchDelay;
+            set
+            {
+                LauncherSettingsProvider.Instance.AutoLaunchDelay = value;
+                this.RaisePropertyChanged();
+            }
+        }
     }
 }

--- a/project/SPT.Launcher/Views/SettingsView.axaml
+++ b/project/SPT.Launcher/Views/SettingsView.axaml
@@ -68,6 +68,19 @@
     
     <CheckBox Grid.Row="4" Grid.Column="1" Content="{Binding Source={x:Static helpers:LocalizationProvider.Instance}, Path=dev_mode}" IsChecked="{Binding Source={x:Static helpers:LauncherSettingsProvider.Instance}, Path=IsDevMode}"/>
     
+    <!-- Auto Launch Game -->
+    <StackPanel Grid.Row="4" Grid.Column="2">
+      <CheckBox Content="Автоматически запускать игру после авторизации" 
+                IsChecked="{Binding AutoLaunchGame}" />
+      <StackPanel Orientation="Horizontal" Margin="20 5 0 0" IsVisible="{Binding AutoLaunchGame}">
+        <Label Content="Задержка (сек):" VerticalAlignment="Center" />
+        <TextBox Text="{Binding AutoLaunchDelay}" 
+                 Width="50" 
+                 Margin="5 0 0 0" 
+                 VerticalContentAlignment="Center" />
+      </StackPanel>
+    </StackPanel>
+    
     <!-- Game Path -->
     <StackPanel Grid.Row="5" Grid.Column="1" Margin="0 10 10 10" IsEnabled="{Binding Source={x:Static helpers:LauncherSettingsProvider.Instance}, Path=IsDevMode}">
       <Label Content="{Binding Source={x:Static helpers:LocalizationProvider.Instance}, Path=game_path}"

--- a/project/SPT.Launcher/Views/SettingsView.axaml
+++ b/project/SPT.Launcher/Views/SettingsView.axaml
@@ -70,10 +70,11 @@
     
     <!-- Auto Launch Game -->
     <StackPanel Grid.Row="4" Grid.Column="2">
-      <CheckBox Content="Автоматически запускать игру после авторизации" 
+      <CheckBox Content="{Binding Source={x:Static helpers:LocalizationProvider.Instance}, Path=auto_launch_game}" 
                 IsChecked="{Binding AutoLaunchGame}" />
       <StackPanel Orientation="Horizontal" Margin="20 5 0 0" IsVisible="{Binding AutoLaunchGame}">
-        <Label Content="Задержка (сек):" VerticalAlignment="Center" />
+        <Label Content="{Binding Source={x:Static helpers:LocalizationProvider.Instance}, Path=auto_launch_delay}" 
+               VerticalAlignment="Center" />
         <TextBox Text="{Binding AutoLaunchDelay}" 
                  Width="50" 
                  Margin="5 0 0 0" 


### PR DESCRIPTION
   ## 🚀 Auto-Launch Game Feature
   
   This PR adds an auto-launch game feature to the SPT-AKI Launcher.
   
   ### ✨ Features
   - **Auto-launch toggle** in Settings with localization support
   - **Configurable delay** (default: 5 seconds) before launching
   - **Multi-language support** for all existing locales
   - **Seamless integration** with existing authentication flow
   
   ### 🎯 Use Case
   Users can now automatically launch the game after successful authentication, 
   eliminating the need to manually click "Launch Game" every time.
   
   ### 🔧 Technical Details
   - Added `AutoLaunchGame` and `AutoLaunchDelay` settings
   - UI controls in Settings view with proper data binding
   - Auto-launch logic in ProfileViewModel with timer
   - Full localization support for all languages
   - Maintains existing functionality and code style
   
   ### �� Testing
   - ✅ Builds successfully
   - ✅ Localization works on all languages
   - ✅ Settings persist between sessions
   - ✅ Auto-launch works with configurable delay

<img width="780" height="491" alt="image" src="https://github.com/user-attachments/assets/1906ce9c-abd4-40f1-9a9c-8f95b5f7d423" />
