### PR TITLE
Fix build scripts for Linux environments

### DIFF
--- a/project/PublishLin.ps1
+++ b/project/PublishLin.ps1
@@ -1,8 +1,8 @@
-﻿dotnet build "./SPTarkov.Core/SPTarkov.Core.csproj" -c release -p:OutputType=Library
+﻿dotnet build "./SPTarkov.Core/SPTarkov.Core.csproj" -c Release -p:OutputType=Library
 Copy-Item "./SPTarkov.Core/bin/Release/net9.0/MudBlazor.min.css" "./SPTarkov.Launcher/wwwroot/MudBlazor.min.css"
 Copy-Item "./SPTarkov.Core/bin/Release/net9.0/MudBlazor.min.js" "./SPTarkov.Launcher/wwwroot/MudBlazor.min.js"
-dotnet publish "./SPTarkov.Launcher/SPTarkov.Launcher.csproj" -c release --self-contained false --framework net9.0 --runtime linux-x64 -p:PublishSingleFile=true
-Remove-Item "./Build" -Recurse -Force
-mkdir "./Build" -Force
-Copy-Item "./SPTarkov.Launcher/bin/release/net9.0/linux-x64/publish/SPTarkov.Launcher" "./Build/SPTarkov.Launcher.Linux"
+dotnet publish "./SPTarkov.Launcher/SPTarkov.Launcher.csproj" -c Release --self-contained false --framework net9.0 --runtime linux-x64 -p:PublishSingleFile=true
+if (Test-Path -Path "./Build") { Remove-Item "./Build" -Recurse -Force }
+New-Item -Path "./" -Name "Build" -ItemType "Directory"
+Copy-Item "./SPTarkov.Launcher/bin/Release/net9.0/linux-x64/publish/SPTarkov.Launcher" "./Build/SPTarkov.Launcher.Linux"
 Copy-Item "./SPTarkov.Core/SPT_Data" "./Build/SPT_Data" -Recurse

--- a/project/PublishWin.ps1
+++ b/project/PublishWin.ps1
@@ -1,9 +1,9 @@
-﻿dotnet build "./SPTarkov.Core/SPTarkov.Core.csproj" -c release -p:OutputType=Library
+﻿dotnet build "./SPTarkov.Core/SPTarkov.Core.csproj" -c Release -p:OutputType=Library
 Copy-Item "./SPTarkov.Core/bin/Release/net9.0/MudBlazor.min.css" "./SPTarkov.Launcher/wwwroot/MudBlazor.min.css"
 Copy-Item "./SPTarkov.Core/bin/Release/net9.0/MudBlazor.min.js" "./SPTarkov.Launcher/wwwroot/MudBlazor.min.js"
-dotnet publish "./SPTarkov.Launcher/SPTarkov.Launcher.csproj" -c release --self-contained false --framework net9.0 --runtime win-x64 -p:PublishSingleFile=true
-Remove-Item "./Build" -Recurse -Force
-mkdir "./Build" -Force
+dotnet publish "./SPTarkov.Launcher/SPTarkov.Launcher.csproj" -c Release --self-contained false --framework net9.0 --runtime win-x64 -p:PublishSingleFile=true
+if (Test-Path -Path "./Build") { Remove-Item "./Build" -Recurse -Force }
+New-Item -Path "./" -Name "Build" -ItemType "Directory"
 Copy-Item "./SPTarkov.Launcher/bin/Release/net9.0/win-x64/publish/SPTarkov.Launcher.exe" "./Build/SPTarkov.Launcher.exe"
 Copy-Item "./SPTarkov.Core/SPT_Data" "./Build/SPT_Data" -Recurse
 


### PR DESCRIPTION
Tested on Fedora Linux 42.

Made some tiny changes to the PS scripts to get both working in a Linux environment:
1. Replaced all occurrences of `release` with `Release` (also the `-c Release` ones since the directory will be created upper-case if it's set like this)
2. Added `Test-Path` check to make sure `./Build` exists before removing it since otherwise a error will be printed
3. Changed `mkdir` to PS equivalent because otherwise it looks like it will use the Linux native `mkdir` command instead