### PR TITLE
Micro-fix of adding steam user support.

### DIFF
--- a/project/SPT.Launcher.Base/Helpers/ValidationUtil.cs
+++ b/project/SPT.Launcher.Base/Helpers/ValidationUtil.cs
@@ -1,19 +1,34 @@
+using Microsoft.VisualBasic;
+using System;
 using Microsoft.Win32;
+using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace SPT.Launcher.Helpers
 {
     public static class ValidationUtil
     {
+        static string c0 = @"Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\EscapeFromTarkov";
+        static string c1 = @"Software\Wow6432Node\Valve\Steam";
+        static string c2 = "build";
+        static string c3 = "3932890";
         public static bool Validate()
         {
-            var c0 = @"Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\EscapeFromTarkov";
+            var b1 = true;
             var v0 = 0;
 
             try
             {
-                var v1 = Registry.LocalMachine.OpenSubKey(c0, false).GetValue("InstallLocation");
+                //var v1 = Registry.LocalMachine.OpenSubKey(c0, false).GetValue("InstallLocation");
+                var v1 = a() as object;
+                if (v1 == null || !Path.Exists(Path.Combine(v1.ToString(), c2)))
+                {
+                    b1 = false;
+                    v1 = Registry.LocalMachine.OpenSubKey(c0, false).GetValue("InstallLocation");
+                }
                 var v2 = (v1 != null) ? v1.ToString() : string.Empty;
+                v2 = b1 ? Path.Combine(v2, c2) : v2;
                 var v3 = new DirectoryInfo(v2);
                 var v4 = new FileSystemInfo[]
                 {
@@ -39,8 +54,57 @@ namespace SPT.Launcher.Helpers
             {
                 v0 = -1;
             }
-
+            //My little brain can't understand why v0 is used like this :doro_cry:
             return v0 == 0;
         }
+
+        public static string a()
+        {
+            var c = b();
+            if (string.IsNullOrEmpty(c))
+                return null;
+
+            var f = d(Path.Combine(c, "steamapps", "libraryfolders.vdf"), "path");
+            return f.Length > 0 ? g(f) : null;
+        }
+
+        private static string b()
+        {
+            var h = string.Empty;
+            using (var i = Registry.LocalMachine.OpenSubKey(c1, false))
+                if (i != null) h = i.GetValue("InstallPath")?.ToString();
+
+            return h;
+        }
+
+        private static string g(string[] j)
+        {
+            var k = $"appmanifest_{c3}.acf";
+            foreach (var l in j)
+            {
+                var m = Path.Combine(l, "steamapps", k);
+                if (!File.Exists(m)) continue;
+
+                var n = d(m, "installdir");
+                if (n.Length > 0) return Path.Combine(l, "steamapps", "common", n[0]);
+            }
+
+            return null;
+        }
+
+        private static string[] d(string l, string k)
+        {
+            if (!File.Exists(l)) return Array.Empty<string>();
+            var q = new List<string>();
+            var s = $@"""{k}""\s+""(.*)""";
+            foreach (var r in File.ReadLines(l))
+            {
+                var p = Regex.Match(r, s);
+                if (p.Success) q.Add(Regex.Unescape(p.Groups[1].Value));
+            }
+
+            return q.ToArray();
+        }
+
     }
 }


### PR DESCRIPTION
Backported steam tarkov detection logic from latest launcher.
With 3.11 being an LTS version, this may help several users until almost every mod is updated to 4.0