### PR TITLE
[Linux] Support different umu executable formats + Add default environment variables

### DIFF
--- a/project/SPTarkov.Core/Configuration/LinuxSettings.cs
+++ b/project/SPTarkov.Core/Configuration/LinuxSettings.cs
@@ -18,4 +18,7 @@ public record LinuxSettings
     public string ProtonVersion { get; set; } = "GE-Proton11-1";
 
     public bool GameMode { get; set; }
+
+    /// <summary>Default environment variables required to run the client.</summary>
+    public string DefaultEnv { get; set; } = @"WINEDLLOVERRIDES=""winhttp=n,b""";
 }

--- a/project/SPTarkov.Core/Helpers/LinuxHelper.cs
+++ b/project/SPTarkov.Core/Helpers/LinuxHelper.cs
@@ -51,6 +51,9 @@ public class LinuxHelper(ILogger<LinuxHelper> logger, ConfigHelper configHelper)
         // this looks something like this: "GE-Proton10-24"
         var proton = configHelper.GetConfig().LinuxSettings.ProtonVersion;
 
+        // This looks something like this: "WINEDLLOVERRIDES="winhttp=n,b" ENV2=2"
+        var DefaultEnv = configHelper.GetConfig().LinuxSettings.DefaultEnv;
+
         if (string.IsNullOrEmpty(prefixPath) || string.IsNullOrEmpty(umuPath) || string.IsNullOrEmpty(proton))
         {
             logger.LogError("Prefix path or umu path or proton version are required");
@@ -98,7 +101,18 @@ public class LinuxHelper(ILogger<LinuxHelper> logger, ConfigHelper configHelper)
             }
         }
 
-        foreach (var token in TokenizeLaunchSettings(configHelper.GetConfig().LinuxSettings.LaunchSettings))
+        // Combine DefaultEnv with LaunchSettings tokens
+        var tokens = new List<string>();
+
+        if (!string.IsNullOrEmpty(DefaultEnv))
+        {
+            tokens.Add(DefaultEnv);
+        }
+
+        tokens.AddRange(TokenizeLaunchSettings(configHelper.GetConfig().LinuxSettings.LaunchSettings));
+
+        // Process all tokens with the same logic
+        foreach (var token in tokens)
         {
             var separator = token.IndexOf('=');
 
@@ -110,7 +124,9 @@ public class LinuxHelper(ILogger<LinuxHelper> logger, ConfigHelper configHelper)
             }
 
             // indexer not Add, a repeated name should overwrite instead of throwing
-            process.Environment[token[..separator]] = token[(separator + 1)..];
+            // Remove quotes from value if present
+            var value = token[(separator + 1)..].Trim('"');
+            process.Environment[token[..separator]] = value;
         }
 
         try

--- a/project/SPTarkov.Core/Helpers/LinuxHelper.cs
+++ b/project/SPTarkov.Core/Helpers/LinuxHelper.cs
@@ -52,7 +52,7 @@ public class LinuxHelper(ILogger<LinuxHelper> logger, ConfigHelper configHelper)
         var proton = configHelper.GetConfig().LinuxSettings.ProtonVersion;
 
         // This looks something like this: "WINEDLLOVERRIDES="winhttp=n,b" ENV2=2"
-        var DefaultEnv = configHelper.GetConfig().LinuxSettings.DefaultEnv;
+        var defaultEnv = configHelper.GetConfig().LinuxSettings.DefaultEnv;
 
         if (string.IsNullOrEmpty(prefixPath) || string.IsNullOrEmpty(umuPath) || string.IsNullOrEmpty(proton))
         {
@@ -104,9 +104,9 @@ public class LinuxHelper(ILogger<LinuxHelper> logger, ConfigHelper configHelper)
         // Combine DefaultEnv with LaunchSettings tokens
         var tokens = new List<string>();
 
-        if (!string.IsNullOrEmpty(DefaultEnv))
+        if (!string.IsNullOrEmpty(defaultEnv))
         {
-            tokens.Add(DefaultEnv);
+            tokens.Add(defaultEnv);
         }
 
         tokens.AddRange(TokenizeLaunchSettings(configHelper.GetConfig().LinuxSettings.LaunchSettings));

--- a/project/SPTarkov.Core/Helpers/LinuxHelper.cs
+++ b/project/SPTarkov.Core/Helpers/LinuxHelper.cs
@@ -80,12 +80,12 @@ public class LinuxHelper(ILogger<LinuxHelper> logger, ConfigHelper configHelper)
         {
             process = new ProcessStartInfo
             {
-                FileName = "python3",
+                FileName = umuPath,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 WorkingDirectory = sptPath,
                 Environment = { { "WINEPREFIX", prefixPath }, { "PROTONPATH", proton } },
-                ArgumentList = { umuPath, cmd },
+                ArgumentList = { cmd },
             };
         }
 


### PR DESCRIPTION
Some improvements to the Linux Launcher with the following changes:

- Adds support for different `umu-run` executable formats to fix issues on distributions that use custom bash wrapper scripts instead of the `umu-run` executable directly like NixOS

- Adds `WINEDLLOVERRIDES="winhttp=n,b"` as environment variable by default since it's a hard requirement for the game client to run. The environment variables are added before the `LaunchSettings` and therefor can be overridden by the user by simply adding the environment variable to the `Launch Settings` field with their custom settings.

Fixes #35. (Thanks @ThunderArtist)