### PR TITLE
Add path validation for user settings

### DIFF
--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Simplified).json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Simplified).json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "已清理临时文件",
   "setting_copy_logs_error_1": "无法将日志复制到剪贴板",
   "setting_copy_logs_success": "已将日志复制到剪贴板",
+  "setting_save_path_error_1": "路径无效",
+  "setting_save_path_error_2": "指定的路径无效，或者文件/目录不存在",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "版本",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Traditional).json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Traditional).json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "已清理臨時檔案",
   "setting_copy_logs_error_1": "無法將日誌複製到剪貼簿",
   "setting_copy_logs_success": "已將日誌複製到剪貼簿",
+  "setting_save_path_error_1": "路徑無效",
+  "setting_save_path_error_2": "指定的路徑無效，或者文件/目錄不存在",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "版本",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/English.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/English.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "Cleaned temp files",
   "setting_copy_logs_error_1": "Unable to set clipboard with logs",
   "setting_copy_logs_success": "Copied logs to clipboard",
+  "setting_save_path_error_1": "Invalid path",
+  "setting_save_path_error_2": "The specified path is invalid or the file/directory does not exist",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "Edition",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/French.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/French.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "Fichiers temporaires nettoyés",
   "setting_copy_logs_error_1": "Impossible de définir le presse-papiers avec les journaux",
   "setting_copy_logs_success": "Journaux copiés dans le presse-papiers",
+  "setting_save_path_error_1": "Chemin invalide",
+  "setting_save_path_error_2": "Le chemin spécifié est invalide ou le fichier/répertoire n'existe pas",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "Édition",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/German.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/German.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "Temporäre Dateien bereinigt",
   "setting_copy_logs_error_1": "Logs konnten nicht in die Zwischenablage kopiert werden",
   "setting_copy_logs_success": "Logs in Zwischenablage kopiert",
+  "setting_save_path_error_1": "Ungültiger Pfad",
+  "setting_save_path_error_2": "Der angegebene Pfad ist ungültig oder die Datei/das Verzeichnis existiert nicht",
   "profile_add_title": "Profil erstellen",
   "profile_add_text": "Erstelle ein neues Profil auf diesem Server.",
   "profile_add_edition": "Edition",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Italian.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Italian.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "File temporanei puliti",
   "setting_copy_logs_error_1": "Impossibile copiare i log negli appunti",
   "setting_copy_logs_success": "Log copiati negli appunti",
+  "setting_save_path_error_1": "Percorso non valido",
+  "setting_save_path_error_2": "Il percorso specificato non è valido o il file/la directory non esiste",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "Edizione",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Korean.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Korean.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "임시 파일 정리됨",
   "setting_copy_logs_error_1": "로그를 클립보드에 설정할 수 없음",
   "setting_copy_logs_success": "로그를 클립보드에 복사함",
+  "setting_save_path_error_1": "잘못된 경로",
+  "setting_save_path_error_2": "지정된 경로가 잘못되었거나 파일/디렉토리가 존재하지 않습니다",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "에디션",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Polish.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Polish.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "Wyczyszczono pliki tymczasowe",
   "setting_copy_logs_error_1": "Nie można skopiować logów do schowka",
   "setting_copy_logs_success": "Skopiowano logi do schowka",
+  "setting_save_path_error_1": "Nieprawidłowa ścieżka",
+  "setting_save_path_error_2": "Określona ścieżka jest nieprawidłowa lub plik/katalog nie istnieje",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "Edycja",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Russian.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Russian.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "Временные файлы очищены",
   "setting_copy_logs_error_1": "Не удалось скопировать логи в буфер обмена",
   "setting_copy_logs_success": "Логи скопированы в буфер обмена",
+  "setting_save_path_error_1": "Неверный путь",
+  "setting_save_path_error_2": "Указанный путь неверный или файл/каталог не существует",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "Издание",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Spanish.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Spanish.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "Archivos temporales limpiados",
   "setting_copy_logs_error_1": "No se puede copiar los registros al portapapeles",
   "setting_copy_logs_success": "Registros copiados al portapapeles",
+  "setting_save_path_error_1": "Ruta no válida",
+  "setting_save_path_error_2": "La ruta especificada no es válida o el archivo/directorio no existe",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "Edición",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Turkish.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Turkish.json
@@ -85,6 +85,8 @@
   "setting_clean_temp_success": "Geçici dosyalar temizlendi",
   "setting_copy_logs_error_1": "Günlükler panoya kopyalanamıyor",
   "setting_copy_logs_success": "Günlükler panoya kopyalandı",
+  "setting_save_path_error_1": "Geçersiz yol",
+  "setting_save_path_error_2": "Belirtilen yol geçersiz veya dosya/dizin mevcut değil",
   "profile_add_title": "Create Profile",
   "profile_add_text": "Create a new profile on this server.",
   "profile_add_edition": "Sürüm",

--- a/project/SPTarkov.Launcher/Components/Settings/SettingGamePath.razor
+++ b/project/SPTarkov.Launcher/Components/Settings/SettingGamePath.razor
@@ -1,12 +1,13 @@
 @inject ConfigHelper ConfigHelper
 @inject LocaleHelper LocaleHelper
+@inject ISnackbar Snackbar
 
 <MudContainer Class="pa-0">
     <SettingSwitchComponent Switch="@Enabled" OptionName="@(LocaleHelper.Get("setting_set_game_path"))" SwitchFunc="SetEnabled" />
     <MudLink Color="Color.Default" Underline="Underline.None" Disabled="!Enabled" Class="@(GetLinkClasses())">
         <MudTextField @bind-Value="NewValue" Label="@(LocaleHelper.Get("setting_game_path"))" Variant="Variant.Outlined" Immediate="true"
                       Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Folder" AdornmentColor="Color.Info"
-                      OnAdornmentClick="SetGamePath" Disabled="!Enabled" />
+                      OnAdornmentClick="SetGamePath" Error="@(HasError)" ErrorText="@(LocaleHelper.Get("setting_save_path_error_1"))" Disabled="!Enabled" />
         <MudIconButton Color="@(IsSaved ? Color.Default : Color.Success)" Icon="@Icons.Material.Filled.Save"
                        Disabled="IsSaved || !Enabled" OnClick="Save"/>
     </MudLink>
@@ -25,6 +26,8 @@
     public bool AddDiv { get; set; }
 
     private string NewValue { get; set; } = "";
+
+    private bool HasError = false;
 
     // Compared against the config rather than a cached copy, so the button cant claim unsaved edits that arent there.
     private bool IsSaved => NewValue == ConfigHelper.GetConfig().GamePath;
@@ -65,6 +68,7 @@
         }
 
         NewValue = folder.FirstOrDefault()!;
+        HasError = false;
         Save();
     }
 
@@ -80,6 +84,13 @@
 
     private void Save()
     {
+        if (!System.IO.Directory.Exists(NewValue))
+        {
+            HasError = true;
+            Snackbar.Add(LocaleHelper.Get("setting_save_path_error_2"), Severity.Error);
+            return;
+        }
+
         ConfigHelper.SetGamePath(NewValue);
         StateHasChanged();
     }

--- a/project/SPTarkov.Launcher/Components/Settings/SettingLinuxPrefixComponent.razor
+++ b/project/SPTarkov.Launcher/Components/Settings/SettingLinuxPrefixComponent.razor
@@ -1,11 +1,13 @@
 @inject ConfigHelper ConfigHelper
 @inject LocaleHelper LocaleHelper
+@inject ISnackbar Snackbar
 
 <MudContainer Class="pa-0">
     <MudLink Color="Color.Default" Underline="Underline.None" Disabled="Disabled" Class="@(GetLinkClasses())">
         <MudTextField @bind-Value="NewValue" Label="@(LocaleHelper.Get("linux_wine_prefix"))"
                       Variant="Variant.Outlined" Immediate="true" Margin="Margin.Dense" Adornment="Adornment.End"
-                      AdornmentIcon="@Icons.Material.Filled.Folder" AdornmentColor="Color.Info" OnAdornmentClick="SetPrefixPath"/>
+                      AdornmentIcon="@Icons.Material.Filled.Folder" AdornmentColor="Color.Info" OnAdornmentClick="SetPrefixPath"
+                      Error="@(HasError)" ErrorText="@(LocaleHelper.Get("setting_save_path_error_1"))"/>
         <MudIconButton Color="@(IsSaved ? Color.Default : Color.Success)" Icon="@Icons.Material.Filled.Save"
                        Disabled="IsSaved" OnClick="Save"/>
     </MudLink>
@@ -24,6 +26,8 @@
     public bool AddDiv { get; set; }
 
     private string NewValue { get; set; } = "";
+
+    private bool HasError = false;
 
     // Compared against the config rather than a cached copy, so the button cant claim unsaved edits that arent there.
     private bool IsSaved => NewValue == ConfigHelper.GetConfig().LinuxSettings.PrefixPath;
@@ -63,11 +67,19 @@
         }
 
         NewValue = folder.FirstOrDefault()!;
+        HasError = false;
         Save();
     }
 
     private void Save()
     {
+        if (!System.IO.Directory.Exists(NewValue))
+        {
+            HasError = true;
+            Snackbar.Add(LocaleHelper.Get("setting_save_path_error_2"), Severity.Error);
+            return;
+        }
+
         ConfigHelper.SetLinuxPrefixPath(NewValue);
         StateHasChanged();
     }

--- a/project/SPTarkov.Launcher/Components/Settings/SettingLinuxUmuComponent.razor
+++ b/project/SPTarkov.Launcher/Components/Settings/SettingLinuxUmuComponent.razor
@@ -1,11 +1,12 @@
 @inject ConfigHelper ConfigHelper
 @inject LocaleHelper LocaleHelper
+@inject ISnackbar Snackbar
 
 <MudContainer Class="pa-0">
     <MudLink Color="Color.Default" Underline="Underline.None" Disabled="Disabled" Class="@(GetLinkClasses())">
         <MudTextField @bind-Value="NewValue" Label="@(LocaleHelper.Get("linux_add_umu"))" Variant="Variant.Outlined" Immediate="true"
                       Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Folder"
-                      AdornmentColor="Color.Info" OnAdornmentClick="SetUmuPath"/>
+                      AdornmentColor="Color.Info" OnAdornmentClick="SetUmuPath" Error="@(HasError)" ErrorText="@(LocaleHelper.Get("setting_save_path_error_1"))"/>
         <MudIconButton Color="@(IsSaved ? Color.Default : Color.Success)" Icon="@Icons.Material.Filled.Save"
                        Disabled="IsSaved" OnClick="Save"/>
     </MudLink>
@@ -23,6 +24,8 @@
     public bool AddDiv { get; set; }
 
     private string NewValue { get; set; } = "";
+
+    private bool HasError = false;
 
     // Compared against the config rather than a cached copy, so the button cant claim unsaved edits that arent there.
     private bool IsSaved => NewValue == ConfigHelper.GetConfig().LinuxSettings.UmuPath;
@@ -63,11 +66,19 @@
         }
 
         NewValue = file.FirstOrDefault()!;
+        HasError = false;
         Save();
     }
 
     private void Save()
     {
+        if (!System.IO.File.Exists(NewValue) || System.IO.Path.GetFileName(NewValue) != "umu-run")
+        {
+            HasError = true;
+            Snackbar.Add(LocaleHelper.Get("setting_save_path_error_2"), Severity.Error);
+            return;
+        }
+
         ConfigHelper.SetLinuxUmuPath(NewValue);
         StateHasChanged();
     }

--- a/project/SPTarkov.Launcher/Dialogs/Linux/LinuxSettingsDialog.razor
+++ b/project/SPTarkov.Launcher/Dialogs/Linux/LinuxSettingsDialog.razor
@@ -13,13 +13,15 @@
                               Required="true" RequiredError="@(LocaleHelper.Get("linux_add_prefix_required"))" Variant="Variant.Outlined"
                               Margin="Margin.Dense" HelperText="/home/cwx/Games/tarkov" HelperTextOnFocus="true" Adornment="Adornment.End"
                               AdornmentIcon="@Icons.Material.Filled.Folder" AdornmentColor="Color.Default"
-                              OnAdornmentClick="SetPrefixPath"/>
+                              OnAdornmentClick="SetPrefixPath" 
+                              Error="@(PrefixError)" ErrorText="@(LocaleHelper.Get("setting_set_path_error_1"))"/>
 
                 <MudTextField Immediate="true" @bind-Value="LinuxSettings!.UmuPath" Label="@(LocaleHelper.Get("linux_add_umu"))"
                               Required="true" RequiredError="@(LocaleHelper.Get("linux_add_umu_required"))" Variant="Variant.Outlined"
                               Margin="Margin.Dense" HelperText="/home/cwx/.local/share/spt-additions/runtime/umu-run"
                               HelperTextOnFocus="true" AdornmentIcon="@Icons.Material.Filled.Folder" Adornment="Adornment.End"
-                              AdornmentColor="Color.Default" OnAdornmentClick="SetUmuPath"/>
+                              AdornmentColor="Color.Default" OnAdornmentClick="SetUmuPath"
+                              Error="@(UmuError)" ErrorText="@(LocaleHelper.Get("setting_set_path_error_1"))"/>
 
                 <MudTextField Immediate="true" @bind-Value="LinuxSettings!.LaunchSettings"
                               Label="@(LocaleHelper.Get("linux_add_launch_settings"))"
@@ -39,7 +41,7 @@
             </MudForm>
             <MudContainer Class="mt-3 d-flex justify-end pa-0 gap-2">
                 <MudButton Class="mud-button-border-copy border-2 border-solid mud-button-inner-text-copy ml-auto" Variant="Variant.Filled"
-                           Color="Color.Primary" Disabled="@(!_success)"
+                           Color="Color.Primary" Disabled="@(!_success || UmuError || PrefixError)"
                            OnClick="Submit">@(LocaleHelper.Get("linux_add_confirm"))</MudButton>
             </MudContainer>
         </MudContainer>
@@ -56,6 +58,15 @@
 
     [CascadingParameter] private IMudDialogInstance? MudDialog { get; set; }
 
+    private bool UmuError => string.IsNullOrEmpty(LinuxSettings!.UmuPath) || 
+                            !System.IO.File.Exists(LinuxSettings.UmuPath) || 
+                            System.IO.Path.GetFileName(LinuxSettings.UmuPath) != "umu-run";
+
+    private bool PrefixError => string.IsNullOrEmpty(LinuxSettings!.PrefixPath) || 
+                                !System.IO.Directory.Exists(LinuxSettings.PrefixPath);
+
+    private bool PathsAreValid => !UmuError && !PrefixError;
+
     protected override async Task OnParametersSetAsync()
     {
         ProtonList = await LinuxHelper.GetProtonVersions();
@@ -66,6 +77,12 @@
 
     private void Submit()
     {
+        if (!PathsAreValid)
+        {
+            Snackbar.Add(LocaleHelper.Get("setting_set_path_error_2"), Severity.Error);
+            return;
+        }
+
         ConfigHelper.SetLinuxSettings(LinuxSettings!);
 
         Snackbar.Add(LocaleHelper.Get("linux_add_success"), Severity.Success);


### PR DESCRIPTION
Improves changing settings by validating paths & giving visual user feedback using `SnackBar` alert boxes:

- Checks if a file/directory exists at the given path
- Checks if a given path is valid
- Checks if `UmuPath` setting is actually set to an `umu-run` executable file
- Adds localized error messages

Tested with Game Path changes (901835f522edc745403a799797576a651e084cfe) & seemed to work just fine.

<img width="1182" height="693" alt="grafik" src="https://github.com/user-attachments/assets/c369dbec-4a67-4fef-b231-e44ec6d00830" />
