### PR TITLE
Add enhanced Proton detection

### DIFF
--- a/project/SPTarkov.Core/Helpers/LinuxHelper.cs
+++ b/project/SPTarkov.Core/Helpers/LinuxHelper.cs
@@ -226,28 +226,28 @@ public class LinuxHelper(ILogger<LinuxHelper> logger, ConfigHelper configHelper)
     {
         // Should contain things like "GE-Proton10-24" or "GE-Proton10-21"
         // Could be named slightly different if user downloads "custom" ones like "EM-10.0-30"
-        if (!Directory.Exists(Paths.ProtonPath))
+        var protons = new List<string>();
+        foreach (var pathWithProtons in Paths.ProtonPaths)
         {
-            logger.LogError("Proton path not found, make sure to run lutris or steam first");
-            // we want this to throw an exception, so just log this
-        }
-
-        var directoryContents = Directory.GetDirectories(Paths.ProtonPath);
-        var listStripped = new List<string>();
-
-        foreach (var directory in directoryContents)
-        {
-            // remove LegacyRuntime
-            if (directory.Contains("LegacyRuntime"))
+            if (!Directory.Exists(pathWithProtons))
             {
                 continue;
             }
 
-            // split on / and get last
-            listStripped.Add(directory.Split("/").Last());
+            var directoryContents = Directory.GetDirectories(pathWithProtons);
+            foreach (var directory in directoryContents)
+            {
+                // remove LegacyRuntime
+                if (directory.Contains("LegacyRuntime"))
+                {
+                    continue;
+                }
+
+                protons.Add(directory.ToString());
+            }
         }
 
-        return Task.FromResult(listStripped);
+        return Task.FromResult(protons);
     }
 
     [DllImport("libc", EntryPoint = "setenv", SetLastError = true)]

--- a/project/SPTarkov.Core/Spt/Paths.cs
+++ b/project/SPTarkov.Core/Spt/Paths.cs
@@ -18,6 +18,7 @@ public class Paths
     public static readonly string[] ProtonPaths = {
         Path.Join(_userProfile, ".local", "share", "Steam", "compatibilitytools.d"),
         Path.Join(_userProfile, ".steam", "steam", "compatibilitytools.d"),
+        Path.Join("usr", "share", "Steam", "compatibilitytools.d"),
         Path.Join(_userProfile, ".local", "share", "lutris", "runners", "proton"),
         Path.Join(_userProfile, ".local", "share", "lutris", "runners", "wine"),
         Path.Join(_userProfile, ".var", "app", "net.lutris.Lutris", "data", "lutris", "runners", "proton"),
@@ -26,7 +27,6 @@ public class Paths
         Path.Join(_userProfile, ".config", "heroic", "tools", "wine"),
         Path.Join(_userProfile, ".var", "app", "com.heroicgameslauncher.hgl", "config", "heroic", "tools", "proton"),
         Path.Join(_userProfile, ".var", "app", "com.heroicgameslauncher.hgl", "config", "heroic", "tools", "wine"),
-        Path.Join("usr", "share", "Steam", "compatibilitytools.d"),
     };
 
     public static readonly string PatchPath = Path.Join(_runtimeRoot, "SPT_Data", "Launcher", "Patches");

--- a/project/SPTarkov.Core/Spt/Paths.cs
+++ b/project/SPTarkov.Core/Spt/Paths.cs
@@ -26,6 +26,7 @@ public class Paths
         Path.Join(_userProfile, ".config", "heroic", "tools", "wine"),
         Path.Join(_userProfile, ".var", "app", "com.heroicgameslauncher.hgl", "config", "heroic", "tools", "proton"),
         Path.Join(_userProfile, ".var", "app", "com.heroicgameslauncher.hgl", "config", "heroic", "tools", "wine"),
+        Path.Join("usr", "share", "Steam", "compatibilitytools.d"),
     };
 
     public static readonly string PatchPath = Path.Join(_runtimeRoot, "SPT_Data", "Launcher", "Patches");

--- a/project/SPTarkov.Core/Spt/Paths.cs
+++ b/project/SPTarkov.Core/Spt/Paths.cs
@@ -12,7 +12,22 @@ public class Paths
     private static readonly string _userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
     private static readonly string _applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
-    public static readonly string ProtonPath = Path.Join(_userProfile, ".local", "share", "Steam", "compatibilitytools.d");
+    // Listing the common directories in which Protons are installed.
+    // Could also add Bottles runner directories but I don't know those.
+    // We should also add a way to add a path manually in case it's a custom one.
+    public static readonly string[] ProtonPaths = {
+        Path.Join(_userProfile, ".local", "share", "Steam", "compatibilitytools.d"),
+        Path.Join(_userProfile, ".steam", "steam", "compatibilitytools.d"),
+        Path.Join(_userProfile, ".local", "share", "lutris", "runners", "proton"),
+        Path.Join(_userProfile, ".local", "share", "lutris", "runners", "wine"),
+        Path.Join(_userProfile, ".var", "app", "net.lutris.Lutris", "data", "lutris", "runners", "proton"),
+        Path.Join(_userProfile, ".var", "app", "net.lutris.Lutris", "data", "lutris", "runners", "wine"),
+        Path.Join(_userProfile, ".config", "heroic", "tools", "proton"),
+        Path.Join(_userProfile, ".config", "heroic", "tools", "wine"),
+        Path.Join(_userProfile, ".var", "app", "com.heroicgameslauncher.hgl", "config", "heroic", "tools", "proton"),
+        Path.Join(_userProfile, ".var", "app", "com.heroicgameslauncher.hgl", "config", "heroic", "tools", "wine"),
+    };
+
     public static readonly string PatchPath = Path.Join(_runtimeRoot, "SPT_Data", "Launcher", "Patches");
     public static readonly string CoreDllPath = Path.Join("BepInEx", "plugins", "spt", "spt-core.dll");
     public static readonly string HwechoDllPath = Path.Join("EscapeFromTarkov_Data", "Plugins", "x86_64", "hwecho.dll");

--- a/project/SPTarkov.Launcher/Components/Settings/SettingLinuxProtonComponent.razor
+++ b/project/SPTarkov.Launcher/Components/Settings/SettingLinuxProtonComponent.razor
@@ -4,9 +4,7 @@
 
 <MudContainer Class="pa-0">
     <a class="d-flex justify-center align-center @(Disabled ? "" : "cursor-pointer setting-on-hover") py-2 px-5">
-        <MudText Class="no-select">@OptionName</MudText>
-        <MudSpacer/>
-        <MudSelect T="string" Value="_selectedOption" Disabled="@Disabled" Clearable="false" ValueChanged="v => OnValueChanged(v)">
+        <MudSelect T="string" Label="@(LocaleHelper.Get("linux_proton_version"))" Value="_selectedOption" Disabled="@Disabled" Clearable="false" ValueChanged="v => OnValueChanged(v)">
             @foreach (var item in Options)
             {
                 <MudSelectItem Value="@item">@item</MudSelectItem>
@@ -24,7 +22,6 @@
     protected override async Task OnInitializedAsync()
     {
         _selectedOption = ConfigHelper.GetConfig().LinuxSettings.ProtonVersion;
-        OptionName = LocaleHelper.Get("linux_proton_version");
         Options = await LinuxHelper.GetProtonVersions();
         await base.OnInitializedAsync();
     }
@@ -35,7 +32,6 @@
     public bool AddDiv { get; set; }
 
     private List<string> Options { get; set; } = [];
-    private string OptionName { get; set; } = "";
     private string _selectedOption = "";
 
     private void OnValueChanged(string value)


### PR DESCRIPTION
The Launcher only checks a single directory for Protons `~/.local/share/Steam/compatibilitytools.d`

Realistically people install Protons in various locations which means they won't show up in the dropdown setting.

These changes will now check common locations in which Protons are installed (Steam, Lutris, Heroic Games Launcher).

PS: We should also add a way to manually set a Proton path in case it's a custom location. Perhaps a toggle like the one for setting a Game Path.

<img width="1023" height="631" alt="Screenshot from 2026-08-06 16-10-07" src="https://github.com/user-attachments/assets/82d42f02-eb90-4d1e-9a3a-b91968864aea" />
