### PR TITLE
[Linux] Game launch improvements

### DIFF
--- a/project/SPTarkov.Core/Helpers/GameHelper.cs
+++ b/project/SPTarkov.Core/Helpers/GameHelper.cs
@@ -151,6 +151,8 @@ public class GameHelper
             $"-config={{'BackendUrl':'https://{_stateHelper.SelectedServer?.IpAddress}','Version':'live','MatchingVersion':'live'}}",
         ];
 
+        _logger.LogInformation("args: {Args}", string.Join(" ", argsList));
+
         if (!_linuxHelper.RunInPrefix(clientExecutable, argsList))
         {
             return false;

--- a/project/SPTarkov.Core/Helpers/GameHelper.cs
+++ b/project/SPTarkov.Core/Helpers/GameHelper.cs
@@ -347,11 +347,12 @@ public class GameHelper
     /// <returns></returns>
     public async Task<bool> MonitorGame()
     {
-        // As wine can take some time to start the game, we'll just delay 12seconds,
-        // needs to search for EscapeFromTarkov for windows
-        // TODO: this might not work for linux
+        // On Linux the process name is cut off - We need to account for that
+        string processName = OperatingSystem.IsWindows() ? "EscapeFromTarkov" : "EscapeFromTarko";
+
+        // Proton can take some time to launch the game, so we'll delay a bit
         await Task.Delay(12000);
-        var process = Process.GetProcessesByName("EscapeFromTarkov").FirstOrDefault();
+        var process = Process.GetProcessesByName(processName).FirstOrDefault();
 
         if (process != null)
         {

--- a/project/SPTarkov.Core/Helpers/GameHelper.cs
+++ b/project/SPTarkov.Core/Helpers/GameHelper.cs
@@ -97,15 +97,12 @@ public class GameHelper
 
         _logger.LogInformation("Valid game path: {ClientExecutable}", clientExecutable);
 
-        Func<bool> launchGame =
-            OperatingSystem.IsWindows() ? () => LaunchGameWindows(clientExecutable)
-            : OperatingSystem.IsLinux() ? () => LaunchGameLinux(clientExecutable)
-            : () =>
-            {
-                return false;
-            };
+        bool success =
+            OperatingSystem.IsWindows() ? LaunchGameWindows(clientExecutable)
+            : OperatingSystem.IsLinux() ? LaunchGameLinux(clientExecutable)
+            : false;
 
-        if (!launchGame())
+        if (!success)
         {
             return false;
         }

--- a/project/SPTarkov.Core/Helpers/GameHelper.cs
+++ b/project/SPTarkov.Core/Helpers/GameHelper.cs
@@ -97,6 +97,24 @@ public class GameHelper
 
         _logger.LogInformation("Valid game path: {ClientExecutable}", clientExecutable);
 
+        Func<bool> launchGame =
+            OperatingSystem.IsWindows() ? () => LaunchGameWindows(clientExecutable)
+            : OperatingSystem.IsLinux() ? () => LaunchGameLinux(clientExecutable)
+            : () =>
+            {
+                return false;
+            };
+
+        if (!launchGame())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool LaunchGameWindows(string clientExecutable)
+    {
         // Start game
         var args =
             $"-force-gfx-jobs native -token={_stateHelper.SelectedProfile?.ProfileId} -config="
@@ -126,12 +144,8 @@ public class GameHelper
         return true;
     }
 
-    public bool LaunchGameLinux()
+    private bool LaunchGameLinux(string clientExecutable)
     {
-        _logger.LogInformation("Launching game on linux");
-        _logger.LogInformation("account name: {acc}", _stateHelper.SelectedProfile?.Username);
-        _logger.LogInformation("Server: {server}", _stateHelper.SelectedServer?.IpAddress);
-
         List<string> argsList =
         [
             "-force-gfx-jobs",
@@ -140,7 +154,7 @@ public class GameHelper
             $"-config={{'BackendUrl':'https://{_stateHelper.SelectedServer?.IpAddress}','Version':'live','MatchingVersion':'live'}}",
         ];
 
-        if (!_linuxHelper.RunInPrefix("EscapeFromTarkov.exe", argsList))
+        if (!_linuxHelper.RunInPrefix(clientExecutable, argsList))
         {
             return false;
         }

--- a/project/SPTarkov.Core/Helpers/GameHelper.cs
+++ b/project/SPTarkov.Core/Helpers/GameHelper.cs
@@ -341,9 +341,6 @@ public class GameHelper
         return true;
     }
 
-    /// <summary>
-    /// </summary>
-    /// <returns></returns>
     public async Task<bool> MonitorGame()
     {
         // On Linux the process name is cut off - We need to account for that

--- a/project/SPTarkov.Launcher/Pages/Profile.razor
+++ b/project/SPTarkov.Launcher/Pages/Profile.razor
@@ -232,23 +232,12 @@
         }
 
         Snackbar.Add(LocaleHelper.Get("profile_page_task_3"));
-        if (OperatingSystem.IsWindows())
+
+        if (!GameHelper.LaunchGame())
         {
-            if (!GameHelper.LaunchGame())
-            {
-                var message = GameHelper.ErrorMessage;
-                Snackbar.Add($"{LocaleHelper.Get("profile_page_task_3_fail")}: {message}", Severity.Error);
-                return;
-            }
-        }
-        else if (OperatingSystem.IsLinux())
-        {
-            if (!GameHelper.LaunchGameLinux())
-            {
-                var message = GameHelper.ErrorMessage;
-                Snackbar.Add($"{LocaleHelper.Get("profile_page_task_3_fail")}: {message}", Severity.Error);
-                return;
-            }
+            var message = GameHelper.ErrorMessage;
+            Snackbar.Add($"{LocaleHelper.Get("profile_page_task_3_fail")}: {message}", Severity.Error);
+            return;
         }
 
         // If enabled, remember this server/profile so the next launcher startup can auto-connect straight to the profile page.


### PR DESCRIPTION
This PR reduces duplicate launch code, ensures that both Linux and Windows share the same game launch pre-checks + log messages & also fixes process monitoring on Linux by checking for the correct process name / identifier which is malformed when launching through Proton. With working process monitoring, the profile stats also update correctly now when the game is closed instead of requiring a re-launch.

I tried to not touch the windows launch code other then moving it to it's own private function.

- **Tested on Linux only**
