### PR TITLE
Fix un-localized "no character created yet" profile string

### DIFF
--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Simplified).json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Simplified).json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "正在启动游戏",
   "profile_page_task_3_fail": "游戏启动失败",
   "profile_page_game_closed": "游戏已关闭",
+  "profile_no_character": "尚未创建角色",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Traditional).json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Chinese (Traditional).json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "正在啟動遊戲",
   "profile_page_task_3_fail": "遊戲啟動失敗",
   "profile_page_game_closed": "遊戲已關閉",
+  "profile_no_character": "尚未創建角色",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/English.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/English.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Launching Game",
   "profile_page_task_3_fail": "Game Failed to start",
   "profile_page_game_closed": "Game has closed",
+  "profile_no_character": "No character created yet",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/French.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/French.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Lancement du jeu",
   "profile_page_task_3_fail": "Échec du démarrage du jeu",
   "profile_page_game_closed": "Le jeu a été fermé",
+  "profile_no_character": "Aucun personnage créé pour le moment",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/German.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/German.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Starte Spiel",
   "profile_page_task_3_fail": "Spielstart fehlgeschlagen",
   "profile_page_game_closed": "Spiel wurde beendet",
+  "profile_no_character": "Noch kein Charakter erstellt",
   "profile_level": "Dein Level",
   "profile_needed_exp": "Benötigte EXP",
   "profile_next_level": "Nächstes Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Italian.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Italian.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Avvio del gioco",
   "profile_page_task_3_fail": "Avvio del gioco fallito",
   "profile_page_game_closed": "Il gioco è stato chiuso",
+  "profile_no_character": "Nessun personaggio ancora creato",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Japanese.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Japanese.json
@@ -160,6 +160,7 @@
   "profile_page_task_3": "ゲームを起動中",
   "profile_page_task_3_fail": "ゲームの起動に失敗",
   "profile_page_game_closed": "ゲームが終了しました",
+  "profile_no_character": "キャラクターがまだ作成されていません",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Korean.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Korean.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "게임 실행 중",
   "profile_page_task_3_fail": "게임 시작 실패",
   "profile_page_game_closed": "게임이 종료되었습니다",
+  "profile_no_character": "아직 생성된 캐릭터가 없습니다",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Polish.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Polish.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Uruchamianie gry",
   "profile_page_task_3_fail": "Nie udało się uruchomić gry",
   "profile_page_game_closed": "Gra została zamknięta",
+  "profile_no_character": "Jeszcze nie stworzono żadnej postaci",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Russian.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Russian.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Запуск игры",
   "profile_page_task_3_fail": "Не удалось запустить игру",
   "profile_page_game_closed": "Игра закрыта",
+  "profile_no_character": "Персонаж ещё не создан",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Spanish.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Spanish.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Iniciando juego",
   "profile_page_task_3_fail": "El juego falló al iniciar",
   "profile_page_game_closed": "El juego se ha cerrado",
+  "profile_no_character": "Aún no se ha creado ningún personaje",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Turkish.json
+++ b/project/SPTarkov.Core/SPT_Data/Launcher/Locales/Turkish.json
@@ -162,6 +162,7 @@
   "profile_page_task_3": "Oyun Başlatılıyor",
   "profile_page_task_3_fail": "Oyun başlatılamadı",
   "profile_page_game_closed": "Oyun kapandı",
+  "profile_no_character": "Henüz karakter oluşturulmadı",
   "profile_level": "Your Level",
   "profile_needed_exp": "Needed EXP",
   "profile_next_level": "Next Level",

--- a/project/SPTarkov.Launcher/Pages/Profile.razor
+++ b/project/SPTarkov.Launcher/Pages/Profile.razor
@@ -15,7 +15,7 @@
         <MudButton Class="mud-button-border-copy border-2 border-solid mud-button-inner-text-copy" Disabled="@_buttonDisabled" Variant="Variant.Filled" Color="Color.Dark" OnClick="ReturnToProfiles" StartIcon="@Icons.Material.Filled.ArrowBack" Size="Size.Medium" IconColor="Color.Error">@(LocaleHelper.Get("profile_logout"))</MudButton>
         <div class="profile-name-overlay d-flex flex-row align-center gap-2 no-pointers no-select">
             <MudIcon Icon="@Icons.Material.Filled.Person" Color="Color.Inherit" Style="@ProfileIconStyle"/>
-            <MudText Typo="Typo.h5">@(SelectedMiniProfile.Nickname == "unknown" ? "No character created yet" : SelectedMiniProfile.Nickname)</MudText>
+            <MudText Typo="Typo.h5">@(SelectedMiniProfile.Nickname == "unknown" ? LocaleHelper.Get("profile_no_character") : SelectedMiniProfile.Nickname)</MudText>
         </div>
         <MudSpacer/>
         @if (ShowWipeCheckbox)


### PR DESCRIPTION
- Adds missing localization for `No character yet` string on the Profile page
- Adds machine-translated strings for all languages

I hope that's the last obvious one :smiling_face_with_tear: 